### PR TITLE
Fix number truthiness check

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -195,7 +195,7 @@ impl<'template> Template<'template> {
                             Value::Null => false,
                             Value::Bool(b) => *b,
                             Value::Number(n) => match n.as_f64() {
-                                Some(float) => float == 0.0,
+                                Some(float) => float != 0.0,
                                 None => {
                                     return Err(truthiness_error(self.original_text, path));
                                 }


### PR DESCRIPTION
This PR fixes a bug in checking the truthiness of number values:
template including `{{ if number }}{number} is truthy{{ endif }}` instruction where `number` is `0` results in `0 is truthy` being rendered. 