### PR TITLE
Add method to set default formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+  - Added `TinyTemplate::set_default_formatter` which, for example, allows to dissable HTML-scaping
 
 ## [1.0.4] - 2020-04-25
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,7 @@ pub fn format_unescaped(value: &Value, output: &mut String) -> Result<()> {
 pub struct TinyTemplate<'template> {
     templates: HashMap<&'template str, Template<'template>>,
     formatters: HashMap<&'template str, Box<ValueFormatter>>,
+    default_formatter: Box<ValueFormatter>,
 }
 impl<'template> TinyTemplate<'template> {
     /// Create a new TinyTemplate registry. The returned registry contains no templates, and has
@@ -177,6 +178,7 @@ impl<'template> TinyTemplate<'template> {
         let mut tt = TinyTemplate {
             templates: HashMap::default(),
             formatters: HashMap::default(),
+            default_formatter: Box::new(format),
         };
         tt.add_formatter("unescaped", format_unescaped);
         tt
@@ -187,6 +189,14 @@ impl<'template> TinyTemplate<'template> {
         let template = Template::compile(text)?;
         self.templates.insert(name, template);
         Ok(())
+    }
+
+    /// Changes the default formatter from [`format`](fn.format.html) to `formatter`. Usefull in combination with [`format_unescaped`](fn.format_unescaped.html) to deactivate HTML-escaping
+    pub fn set_default_formatter<F>(&mut self, formatter: F)
+    where
+        F: 'static + Fn(&Value, &mut String) -> Result<()>,
+    {
+        self.default_formatter = Box::new(formatter);
     }
 
     /// Register the given formatter function under the given name.
@@ -205,7 +215,12 @@ impl<'template> TinyTemplate<'template> {
     {
         let value = serde_json::to_value(context)?;
         match self.templates.get(template) {
-            Some(tmpl) => tmpl.render(&value, &self.templates, &self.formatters),
+            Some(tmpl) => tmpl.render(
+                &value,
+                &self.templates,
+                &self.formatters,
+                &self.default_formatter,
+            ),
             None => Err(Error::GenericError {
                 msg: format!("Unknown template '{}'", template),
             }),
@@ -215,5 +230,31 @@ impl<'template> TinyTemplate<'template> {
 impl<'template> Default for TinyTemplate<'template> {
     fn default() -> TinyTemplate<'template> {
         TinyTemplate::new()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[derive(Serialize)]
+    struct Context {
+        name: String,
+    }
+
+    static TEMPLATE: &'static str = "Hello {name}!";
+
+    #[test]
+    pub fn test_set_default_formatter() {
+        let mut tt = TinyTemplate::new();
+        tt.add_template("hello", TEMPLATE).unwrap();
+        tt.set_default_formatter(format_unescaped);
+
+        let context = Context {
+            name: "<World>".to_string(),
+        };
+
+        let rendered = tt.render("hello", &context).unwrap();
+        assert_eq!(rendered, "Hello <World>!")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ pub fn format_unescaped(value: &Value, output: &mut String) -> Result<()> {
 pub struct TinyTemplate<'template> {
     templates: HashMap<&'template str, Template<'template>>,
     formatters: HashMap<&'template str, Box<ValueFormatter>>,
-    default_formatter: Box<ValueFormatter>,
+    default_formatter: &'template ValueFormatter,
 }
 impl<'template> TinyTemplate<'template> {
     /// Create a new TinyTemplate registry. The returned registry contains no templates, and has
@@ -178,7 +178,7 @@ impl<'template> TinyTemplate<'template> {
         let mut tt = TinyTemplate {
             templates: HashMap::default(),
             formatters: HashMap::default(),
-            default_formatter: Box::new(format),
+            default_formatter: &format,
         };
         tt.add_formatter("unescaped", format_unescaped);
         tt
@@ -192,11 +192,11 @@ impl<'template> TinyTemplate<'template> {
     }
 
     /// Changes the default formatter from [`format`](fn.format.html) to `formatter`. Usefull in combination with [`format_unescaped`](fn.format_unescaped.html) to deactivate HTML-escaping
-    pub fn set_default_formatter<F>(&mut self, formatter: F)
+    pub fn set_default_formatter<F>(&mut self, formatter: &'template F)
     where
         F: 'static + Fn(&Value, &mut String) -> Result<()>,
     {
-        self.default_formatter = Box::new(formatter);
+        self.default_formatter = formatter;
     }
 
     /// Register the given formatter function under the given name.
@@ -219,7 +219,7 @@ impl<'template> TinyTemplate<'template> {
                 &value,
                 &self.templates,
                 &self.formatters,
-                &self.default_formatter,
+                self.default_formatter,
             ),
             None => Err(Error::GenericError {
                 msg: format!("Unknown template '{}'", template),
@@ -248,7 +248,7 @@ mod test {
     pub fn test_set_default_formatter() {
         let mut tt = TinyTemplate::new();
         tt.add_template("hello", TEMPLATE).unwrap();
-        tt.set_default_formatter(format_unescaped);
+        tt.set_default_formatter(&format_unescaped);
 
         let context = Context {
             name: "<World>".to_string(),

--- a/src/template.rs
+++ b/src/template.rs
@@ -122,7 +122,7 @@ impl<'template> Template<'template> {
         context: &Value,
         template_registry: &HashMap<&str, Template>,
         formatter_registry: &HashMap<&str, Box<ValueFormatter>>,
-        default_formatter: &Box<ValueFormatter>,
+        default_formatter: &ValueFormatter,
     ) -> Result<String> {
         // The length of the original template seems like a reasonable guess at the length of the
         // output.
@@ -143,7 +143,7 @@ impl<'template> Template<'template> {
         context: &Value,
         template_registry: &HashMap<&str, Template>,
         formatter_registry: &HashMap<&str, Box<ValueFormatter>>,
-        default_formatter: &Box<ValueFormatter>,
+        default_formatter: &ValueFormatter,
         output: &mut String,
     ) -> Result<()> {
         let mut program_counter = 0;
@@ -393,8 +393,8 @@ mod test {
         map
     }
 
-    pub fn default_formatter() -> Box<ValueFormatter> {
-        Box::new(::format)
+    pub fn default_formatter() -> &'static ValueFormatter {
+        &::format
     }
 
     #[test]

--- a/src/template.rs
+++ b/src/template.rs
@@ -743,7 +743,7 @@ mod test {
 
     #[test]
     fn test_unknown() {
-        let template = compile("{ default_formatter }");
+        let template = compile("{ foobar }");
         let context = context();
         let template_registry = other_templates();
         let formatter_registry = formatters();

--- a/src/template.rs
+++ b/src/template.rs
@@ -3,7 +3,6 @@
 use compiler::TemplateCompiler;
 use error::Error::*;
 use error::*;
-use format;
 use instruction::{Instruction, PathSlice};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -123,11 +122,18 @@ impl<'template> Template<'template> {
         context: &Value,
         template_registry: &HashMap<&str, Template>,
         formatter_registry: &HashMap<&str, Box<ValueFormatter>>,
+        default_formatter: &Box<ValueFormatter>,
     ) -> Result<String> {
         // The length of the original template seems like a reasonable guess at the length of the
         // output.
         let mut output = String::with_capacity(self.template_len);
-        self.render_into(context, template_registry, formatter_registry, &mut output)?;
+        self.render_into(
+            context,
+            template_registry,
+            formatter_registry,
+            default_formatter,
+            &mut output,
+        )?;
         Ok(output)
     }
 
@@ -137,6 +143,7 @@ impl<'template> Template<'template> {
         context: &Value,
         template_registry: &HashMap<&str, Template>,
         formatter_registry: &HashMap<&str, Box<ValueFormatter>>,
+        default_formatter: &Box<ValueFormatter>,
         output: &mut String,
     ) -> Result<()> {
         let mut program_counter = 0;
@@ -170,13 +177,13 @@ impl<'template> Template<'template> {
                             }
                             "@root" => {
                                 let value_to_render = render_context.lookup_root()?;
-                                format(value_to_render, output)?;
+                                default_formatter(value_to_render, output)?;
                             }
                             _ => panic!(), // This should have been caught by the parser.
                         }
                     } else {
                         let value_to_render = render_context.lookup(path)?;
-                        format(value_to_render, output)?;
+                        default_formatter(value_to_render, output)?;
                     }
                     program_counter += 1;
                 }
@@ -287,6 +294,7 @@ impl<'template> Template<'template> {
                                 context_value,
                                 template_registry,
                                 formatter_registry,
+                                default_formatter,
                                 output,
                             );
                             if let Err(err) = called_templ_result {
@@ -385,6 +393,10 @@ mod test {
         map
     }
 
+    pub fn default_formatter() -> Box<ValueFormatter> {
+        Box::new(::format)
+    }
+
     #[test]
     fn test_literal() {
         let template = compile("Hello!");
@@ -392,7 +404,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("Hello!", &string);
     }
@@ -404,7 +421,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("5", &string);
     }
@@ -416,7 +438,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("The number of the day is 10.", &string);
     }
@@ -428,7 +455,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("Hello!", &string);
     }
@@ -440,7 +472,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("", &string);
     }
@@ -452,7 +489,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("Hello!", &string);
     }
@@ -464,7 +506,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("Goodbye!", &string);
     }
@@ -476,7 +523,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("", &string);
     }
@@ -488,7 +540,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("Hello!", &string);
     }
@@ -500,7 +557,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("Goodbye!", &string);
     }
@@ -512,7 +574,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("Hello!", &string);
     }
@@ -526,7 +593,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("Hi, Hello!", &string);
     }
@@ -538,7 +610,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("10 5", &string);
     }
@@ -550,7 +627,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("123", &string);
     }
@@ -562,7 +644,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("012", &string);
     }
@@ -575,7 +662,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("0", &string);
     }
@@ -588,7 +680,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("2", &string);
     }
@@ -600,7 +697,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("151", &string);
     }
@@ -612,7 +714,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("10", &string);
     }
@@ -624,19 +731,29 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("{10}", &string);
     }
 
     #[test]
     fn test_unknown() {
-        let template = compile("{ foobar }");
+        let template = compile("{ default_formatter }");
         let context = context();
         let template_registry = other_templates();
         let formatter_registry = formatters();
         template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap_err();
     }
 
@@ -647,7 +764,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("1:&lt; 2:&gt; 3:&amp; 4:&#39; 5:&quot;", &string);
     }
@@ -660,7 +782,12 @@ mod test {
         let mut formatter_registry = formatters();
         formatter_registry.insert("unescaped", Box::new(::format_unescaped));
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("1:< 2:> 3:& 4:' 5:\"", &string);
     }
@@ -673,7 +800,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("Hello World!", &string);
     }
@@ -686,7 +818,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("Hello World!", &string);
     }
@@ -699,7 +836,12 @@ mod test {
         let template_registry = other_templates();
         let formatter_registry = formatters();
         let string = template
-            .render(&context, &template_registry, &formatter_registry)
+            .render(
+                &context,
+                &template_registry,
+                &formatter_registry,
+                &default_formatter(),
+            )
             .unwrap();
         assert_eq!("foobar", &string);
     }


### PR DESCRIPTION
This PR adds the ability to change the default formatter, which makes it possible to disable HTML-escaping.

If this is merged the following issue can be closed:

https://github.com/bheisler/TinyTemplate/issues/8

Let me know if there is a problem. As I wrote in the issue, I'm very new to Rust (this is actually the first thing I created with Rust, besides some exercises from the Rust book). Feel free to tell me if this is complete garbage and you'd like to implement this yourself :)