### PR TITLE
Fix unknown `doc` attribute `Hidden` at nightly

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -41,7 +41,7 @@ pub enum Error {
         column: usize,
     },
 
-    #[doc(Hidden)]
+    #[doc(hidden)]
     __NonExhaustive,
 }
 impl From<SerdeJsonError> for Error {


### PR DESCRIPTION
The `Hidden` `doc` attribute it's no longer valid at nightly