### PR TITLE
Add custom template delimiter

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -289,7 +289,7 @@ impl<'template> TemplateCompiler<'template> {
         let mut position = search_substr
             .find(|chr| self.delimiter_prefix.contains(&chr))
             .unwrap_or_else(|| search_substr.len());
-        if escaped {
+        if escaped || position == 0 {
             position += 1;
         }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -10,6 +10,8 @@ use std::fmt::Write;
 use std::slice;
 use ValueFormatter;
 
+use crate::compiler::Delimiter;
+
 /// Enum defining the different kinds of records on the context stack.
 enum ContextElement<'render, 'template> {
     /// Object contexts shadow everything below them on the stack, because every name is looked up
@@ -116,12 +118,12 @@ pub(crate) struct Template<'template> {
     template_len: usize,
 }
 impl<'template> Template<'template> {
-    /// Create a Template from the given template string.
-    pub fn compile(text: &'template str) -> Result<Template> {
+    /// Create a Template with delimiter from the given template string.
+    pub fn compile_with_delimiter(text: &'template str, delimiter: Delimiter) -> Result<Template> {
         Ok(Template {
             original_text: text,
             template_len: text.len(),
-            instructions: TemplateCompiler::new(text).compile()?,
+            instructions: TemplateCompiler::with_delimiter(text, delimiter).compile()?,
         })
     }
 


### PR DESCRIPTION
This PR allow user change the default template delimiter `{value}`, `{{ block }}` and `{{# component }}`.

The purpose of this PR is to allow TinyTemplate be used in other text generation, no only for HTML. 
In some text, e.g. JavaScript source code, tempalte compiler scan for `"{"` and make all text between `"{"` and `"}"` into template value reference, which in JS code is used as block.
In this case, we could customize the template delimiter to `${value}`, `${{ block }}` and `${{# comment }}` to solve the problem.

This PR adds a type `Delimiter` to let user customize their template delimiter via `TinyTemplate::set_delimiter` before adding their template.

This PR also adds some unit tests for custom delimiter.

## Benchmark
Almost no change in performance comparing to original impelemation.
```rust
parse-table             time:   [1.3309 us 1.3397 us 1.3486 us]
                        change: [-1.3990% -0.2348% +0.9247%] (p = 0.70 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe

render-table/1          time:   [553.60 ns 557.93 ns 562.38 ns]
                        change: [-2.9563% -2.0335% -1.0255%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
render-table/5          time:   [2.1302 us 2.1436 us 2.1585 us]
                        change: [-1.8283% -0.3221% +1.0741%] (p = 0.68 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
render-table/10         time:   [5.7375 us 5.7750 us 5.8196 us]
                        change: [-1.4117% +0.0042% +1.3660%] (p = 0.99 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  3 (3.00%) high severe
render-table/50         time:   [114.09 us 115.49 us 116.99 us]
                        change: [+0.5029% +1.9178% +3.3508%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
render-table/100        time:   [418.06 us 420.44 us 423.12 us]
                        change: [-3.6999% -2.4288% -1.1384%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
Benchmarking render-table/200: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.7s, enable flat sampling, or reduce sample count to 50.
render-table/200        time:   [1.7845 ms 1.7948 ms 1.8051 ms]
                        change: [-2.3162% -0.9980% +0.4313%] (p = 0.16 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
```
