### PR TITLE
Add fuzzing, fix panics

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+
+[package]
+name = "tinytemplate-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.tinytemplate]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "render_template"
+path = "fuzz_targets/render_template.rs"
+test = false
+doc = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,6 +12,14 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 
+# Defines a custom arbitrary, Serialize-able value for inputs.
+[dependencies.arbitrary]
+version = "1"
+features = ["derive"]
+[dependencies.serde]
+version = "1"
+features = ["derive"]
+
 [dependencies.tinytemplate]
 path = ".."
 

--- a/fuzz/fuzz_targets/render_template.rs
+++ b/fuzz/fuzz_targets/render_template.rs
@@ -1,0 +1,12 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &str| {
+    let mut tpl = tinytemplate::TinyTemplate::new();
+
+    if tpl.add_template("template", data).is_err() {
+        return;
+    }
+
+    let _ = tinytemplate::TinyTemplate::new().render("template", &());
+});

--- a/fuzz/fuzz_targets/render_template.rs
+++ b/fuzz/fuzz_targets/render_template.rs
@@ -1,12 +1,24 @@
 #![no_main]
+use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
+use serde::Serialize;
 
-fuzz_target!(|data: &str| {
+#[derive(Arbitrary, Debug, Serialize)]
+enum Value {
+    Bool(bool),
+    Number(f64),
+    String(String),
+    Array(Vec<Value>),
+    Object(std::collections::HashMap<String, Value>),
+}
+
+fuzz_target!(|val: (&str, Value)| {
+    let (data, value) = val;
     let mut tpl = tinytemplate::TinyTemplate::new();
 
     if tpl.add_template("template", data).is_err() {
         return;
     }
 
-    let _ = tinytemplate::TinyTemplate::new().render("template", &());
+    let _ = tinytemplate::TinyTemplate::new().render("template", &value);
 });

--- a/fuzz/fuzz_targets/render_template.rs
+++ b/fuzz/fuzz_targets/render_template.rs
@@ -12,13 +12,17 @@ enum Value {
     Object(std::collections::HashMap<String, Value>),
 }
 
-fuzz_target!(|val: (&str, Value)| {
-    let (data, value) = val;
+fuzz_target!(|val: (&str, Vec<(&str, &str)>, Value)| {
+    let (data, extra, value) = val;
     let mut tpl = tinytemplate::TinyTemplate::new();
 
     if tpl.add_template("template", data).is_err() {
         return;
     }
 
-    let _ = tinytemplate::TinyTemplate::new().render("template", &value);
+    for (name, data) in extra {
+        let _ = tpl.add_template(name, data).is_err();
+    }
+
+    let _ = tpl.render("template", &value);
 });

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -709,4 +709,16 @@ mod test {
         assert_eq!(&Literal("hello "), &instructions[0]);
         assert_eq!(&Literal("{world}"), &instructions[1]);
     }
+
+    #[test]
+    fn test_unmatched_escape() {
+        let text = r#"0\"#;
+        compile(text).unwrap_err();
+    }
+
+    #[test]
+    fn test_mismatched_closing_tag() {
+        let text = "{#}";
+        compile(text).unwrap_err();
+    }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -160,12 +160,19 @@ impl<'template> TemplateCompiler<'template> {
                     }
                     escaped = text.ends_with('\\');
                     if escaped {
-                        text = &text[0..(text.len() - 1)];
+                        text = &text[..text.len() - 1];
                     }
                     self.instructions.push(Instruction::Literal(text));
 
                     if !escaped {
                         break;
+                    }
+
+                    if escaped && self.remaining_text.is_empty() {
+                        return Err(self.parse_error(
+                            text,
+                            "Found an escape that doesn't escape any character.".to_string()
+                        ));
                     }
                 }
             }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -348,10 +348,17 @@ impl<'template> TemplateCompiler<'template> {
     /// Advance the cursor to after the given expected_close string and return the text in between
     /// (including the expected_close characters), or return an error message if we reach the end
     /// of a line of text without finding it.
+    /// Assumes that there's a start token with the same length as the close token at the start of
+    /// currently remaining text.
     fn consume_tag(&mut self, expected_close: &str) -> Result<&'template str> {
+        // We skip over the matching start token for this tag, so that we do not accidentally match
+        // some suffix of it with the close token. We assume that the start token is as long as the
+        // end token.
+        let start_len = expected_close.len();
+        let end_len = expected_close.len();
         if let Some(line) = self.remaining_text.lines().next() {
-            if let Some(pos) = line.find(expected_close) {
-                let (tag, remaining) = self.remaining_text.split_at(pos + expected_close.len());
+            if let Some(pos) = line[start_len..].find(expected_close) {
+                let (tag, remaining) = self.remaining_text.split_at(pos + start_len + end_len);
                 self.remaining_text = remaining;
                 Ok(tag)
             } else {


### PR DESCRIPTION
Based on #23 but also fixes all panics found via such fuzzing. These are essentially already found in issues.

Closes: #22
Closes one other panic in malformed templates: An input ending in a literal with escape `\` would reenter the parsing loop another time with empty input and `escaped` set, but `conume_text` assumes at least one byte to be present when escaped is set.